### PR TITLE
AWS IAM RBAC auth to RDS/Aurora for hault-strimzi env

### DIFF
--- a/aws-cloud/environments/nonprod-asm-msk/main.tf
+++ b/aws-cloud/environments/nonprod-asm-msk/main.tf
@@ -86,6 +86,7 @@ module "eks" {
   private_subnet_ids       = module.network.private_subnets
   route53_private_zone_arn = module.network.aws_route53_private_zone_arn
   kubernetes_version       = var.kubernetes_version
+  tm_iam_prefix            = var.tm_iam_prefix
 }
 
 module "db" {

--- a/aws-cloud/environments/nonprod-asm-msk/terraform.example.tfvars
+++ b/aws-cloud/environments/nonprod-asm-msk/terraform.example.tfvars
@@ -20,3 +20,6 @@ vault_installer_serviceaccount = "vault-installer"
 kafka_mode                     = "sasl-scram"
 postgres_version               = "16.9"
 kubernetes_version             = "1.35"
+# Toggles IAM RBAC auth for database, instead of password. Not supported for ASM MSK mode. Set to false
+iam_db_auth                    = "false"
+tm_db_admin                    = "DB_ADMIN_USERNAME"

--- a/aws-cloud/environments/nonprod-asm-msk/variables.tf
+++ b/aws-cloud/environments/nonprod-asm-msk/variables.tf
@@ -54,3 +54,15 @@ variable "kubernetes_version" {
   type    = string
   default = "1.35"
 }
+
+variable "iam_db_auth" {
+  description = "Toggles IAM RBAC auth for database, instead of password. Not supported for ASM MSK mode. Set to false."
+  type    = bool
+  default = false
+}
+
+variable "tm_db_admin" {
+  description = "Database admin user. Not used in ASM MSK mode."
+  type = string
+  default = "tm_admin"
+}

--- a/aws-cloud/environments/nonprod-hault-strimzi/main.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/main.tf
@@ -121,11 +121,12 @@ module "secrets-manager" {
   project_domain     = var.project_domain
   oidc_provider_arn  = module.eks.oidc_provider_arn
   ingress_class_name = module.eks.ingress_class_name
-  db_cluster_resource_id = var.iam_db_auth ? module.db.cluster_resource_id : null
+  db_cluster_resource_id         = var.iam_db_auth ? module.db.cluster_resource_id : null
   vault_installer_namespace      = var.vault_installer_namespace
   vault_installer_serviceaccount = var.vault_installer_serviceaccount
   tm_iam_prefix                  = var.tm_iam_prefix
-  tm_iam_db_admin    = "tm_admin_iam" # TODO
+  iam_db_auth        = var.iam_db_auth
+  tm_db_admin        = var.tm_db_admin
   dependency         = module.eks.is_ready
 }
 

--- a/aws-cloud/environments/nonprod-hault-strimzi/main.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/main.tf
@@ -93,6 +93,7 @@ module "eks" {
   private_subnet_ids       = module.network.private_subnets
   route53_private_zone_arn = module.network.aws_route53_private_zone_arn
   kubernetes_version       = var.kubernetes_version
+  tm_iam_prefix            = var.tm_iam_prefix
 }
 
 module "db" {
@@ -120,6 +121,11 @@ module "secrets-manager" {
   project_domain     = var.project_domain
   oidc_provider_arn  = module.eks.oidc_provider_arn
   ingress_class_name = module.eks.ingress_class_name
+  db_cluster_resource_id = var.iam_db_auth ? module.db.cluster_resource_id : null
+  vault_installer_namespace      = var.vault_installer_namespace
+  vault_installer_serviceaccount = var.vault_installer_serviceaccount
+  tm_iam_prefix                  = var.tm_iam_prefix
+  tm_iam_db_admin    = "tm_admin_iam" # TODO
   dependency         = module.eks.is_ready
 }
 

--- a/aws-cloud/environments/nonprod-hault-strimzi/outputs.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/outputs.tf
@@ -85,3 +85,7 @@ output "kafka_init_sasl_scram_username" {
 output "kafka_init_sasl_scram_password" {
   value = local.kafka_init_sasl_scram_password
 }
+
+output "vault_installer_role_arn" {
+  value = module.secrets-manager.vault_installer_role_arn
+}

--- a/aws-cloud/environments/nonprod-hault-strimzi/variables.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/variables.tf
@@ -60,3 +60,8 @@ variable "iam_db_auth" {
   type    = bool
   default = false
 }
+
+variable "tm_db_admin" {
+  type = string
+  default = "tm_admin_iam"
+}

--- a/aws-cloud/environments/nonprod-hault-strimzi/variables.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/variables.tf
@@ -57,11 +57,13 @@ variable "kubernetes_version" {
 }
 
 variable "iam_db_auth" {
+  description = "Toggles IAM RBAC auth for database, instead of password."
   type    = bool
   default = false
 }
 
 variable "tm_db_admin" {
+  description = "Database admin user."
   type = string
   default = "tm_admin_iam"
 }

--- a/aws-cloud/environments/nonprod-hault-strimzi/variables.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/variables.tf
@@ -55,3 +55,8 @@ variable "kubernetes_version" {
   type    = string
   default = "1.35"
 }
+
+variable "iam_db_auth" {
+  type    = bool
+  default = false
+}

--- a/aws-cloud/modules/db/aurora-serverless/outputs.tf
+++ b/aws-cloud/modules/db/aurora-serverless/outputs.tf
@@ -13,3 +13,7 @@ output "security_group_id" {
 output "master_username" {
   value = var.master_username
 }
+
+output "cluster_resource_id" {
+  value = module.aurora_postgresql_v2.cluster_resource_id
+}

--- a/aws-cloud/modules/k8s/eks-managed-nodes/addons.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/addons.tf
@@ -2,6 +2,7 @@ module "vpc_cni_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "6.4.0"
   name                  = "vpc-cni"
+  path                  = "/${var.tm_iam_prefix}/"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
   oidc_providers = {
@@ -22,6 +23,7 @@ module "ebs_csi_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "6.4.0"
   name                  = "ebs-csi"
+  path                  = "/${var.tm_iam_prefix}/"
   attach_ebs_csi_policy = true
   oidc_providers = {
     main = {
@@ -59,6 +61,7 @@ module "external_dns_irsa" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                       = "6.4.0"
   name                          = "external-dns"
+  path                          = "/${var.tm_iam_prefix}/"
   attach_external_dns_policy    = true
   external_dns_hosted_zone_arns = [var.route53_private_zone_arn]
   oidc_providers = {

--- a/aws-cloud/modules/k8s/eks-managed-nodes/addons.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/addons.tf
@@ -1,7 +1,7 @@
 module "vpc_cni_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "6.4.0"
-  name                  = "vpc-cni"
+  name                  = "${var.project}-vpc-cni"
   path                  = "/${var.tm_iam_prefix}/"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
@@ -22,7 +22,7 @@ resource "aws_eks_addon" "vpc_cni" {
 module "ebs_csi_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "6.4.0"
-  name                  = "ebs-csi"
+  name                  = "${var.project}-ebs-csi"
   path                  = "/${var.tm_iam_prefix}/"
   attach_ebs_csi_policy = true
   oidc_providers = {
@@ -60,7 +60,7 @@ resource "aws_eks_addon" "external_dns" {
 module "external_dns_irsa" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                       = "6.4.0"
-  name                          = "external-dns"
+  name                          = "${var.project}-external-dns"
   path                          = "/${var.tm_iam_prefix}/"
   attach_external_dns_policy    = true
   external_dns_hosted_zone_arns = [var.route53_private_zone_arn]

--- a/aws-cloud/modules/k8s/eks-managed-nodes/aws_load_balancer_controller.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/aws_load_balancer_controller.tf
@@ -5,6 +5,7 @@ module "aws_load_balancer_controller_irsa_role" {
   source                                 = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                                = "6.4.0"
   name                                   = "aws-load-balancer-controller"
+  path                                   = "/${var.tm_iam_prefix}/"
   attach_load_balancer_controller_policy = true
   oidc_providers = {
     main = {

--- a/aws-cloud/modules/k8s/eks-managed-nodes/aws_load_balancer_controller.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/aws_load_balancer_controller.tf
@@ -4,7 +4,7 @@
 module "aws_load_balancer_controller_irsa_role" {
   source                                 = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                                = "6.4.0"
-  name                                   = "aws-load-balancer-controller"
+  name                                   = "${var.project}-aws-lb-ctrl"
   path                                   = "/${var.tm_iam_prefix}/"
   attach_load_balancer_controller_policy = true
   oidc_providers = {

--- a/aws-cloud/modules/k8s/eks-managed-nodes/cert_manager.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/cert_manager.tf
@@ -8,6 +8,7 @@ module "cert_manager_irsa_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                       = "6.2.1"
   name                          = "${var.project}-cert-manager"
+  path                          = "/${var.tm_iam_prefix}/"
   attach_cert_manager_policy    = true
   cert_manager_hosted_zone_arns = [var.route53_private_zone_arn]
   oidc_providers = {

--- a/aws-cloud/modules/k8s/eks-managed-nodes/main.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/main.tf
@@ -101,6 +101,10 @@ module "eks" {
       }
       use_latest_ami_release_version = false
       eks_ami_release_version        = local.eks_ami_release_version
+      metadata_options = {
+        # Unblock IMDSv2 from pod, workaround for core-db-online-migrator calls ec2imds: GetRegion"
+        http_put_response_hop_limit = 2
+      }
     }
   }
 }

--- a/aws-cloud/modules/k8s/eks-managed-nodes/variables.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/variables.tf
@@ -22,3 +22,7 @@ variable "kubernetes_version" {
   type    = string
   default = "1.35"
 }
+
+variable "tm_iam_prefix" {
+  type = string
+}

--- a/aws-cloud/modules/secrets/aws-secrets-manager/main.tf
+++ b/aws-cloud/modules/secrets/aws-secrets-manager/main.tf
@@ -69,6 +69,7 @@ module "irsa_vault_installer" {
 # permissions boundary for the Vault Installer. vault-installer-policy.json
 resource "aws_iam_policy" "vault_installer_policy" {
   name   = "${var.project}-vault-installer-policy"
+  path   = "/${var.tm_iam_prefix}/"
   policy = data.aws_iam_policy_document.vault_installer_policy.json
 }
 
@@ -120,6 +121,7 @@ data "aws_iam_policy_document" "application_permission_boundary" {
 # vault-role-permission-boundary / application permission boundary
 resource "aws_iam_policy" "application_permission_boundary" {
   name        = "${var.project}-vault-role-permission-boundary"
+  path        = "/${var.tm_iam_prefix}/"
   description = "TM Vault applications permissions to AWS Secret Manager"
   policy      = data.aws_iam_policy_document.application_permission_boundary.json
 }

--- a/aws-cloud/modules/secrets/hashicorp-vault/irsa_installer.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/irsa_installer.tf
@@ -1,0 +1,53 @@
+module "irsa_vault_installer" {
+  count = var.db_cluster_resource_id != null ? 1 : 0
+  depends_on = [local.dependency]
+  source     = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version    = "6.2.1"
+  name       = "${var.project}-vault-installer"
+  policies = {
+    "min_access" = aws_iam_policy.vault_installer_policy[0].arn
+  }
+  permissions_boundary = aws_iam_policy.vault_installer_policy[0].arn # application_permission_boundary.arn
+  oidc_providers = {
+    main = {
+      provider_arn               = var.oidc_provider_arn
+      namespace_service_accounts = ["${var.vault_installer_namespace}:${var.vault_installer_serviceaccount}"]
+    }
+  }
+}
+
+# permissions boundary for the Vault Installer. vault-installer-policy.json
+resource "aws_iam_policy" "vault_installer_policy" {
+  # ?? for_each = var.db_cluster_resource_id != null ? { "enabled" = var.db_cluster_resource_id } : {}
+  count = var.db_cluster_resource_id != null ? 1 : 0
+  name  = "${var.project}-vault-installer-policy"
+  path  = "/${var.tm_iam_prefix}/"
+  policy = data.aws_iam_policy_document.vault_installer_policy[0].json
+}
+
+data "aws_iam_policy_document" "vault_installer_policy" {
+  count = var.db_cluster_resource_id != null ? 1 : 0
+  statement {
+    sid    = "AllowRolesOnlyInPath"
+    effect = "Allow"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${local.aws_account_id}:role/${var.tm_iam_prefix}/*"
+    ]
+  }
+  statement {
+    sid    = "AllowIamDbAuth"
+    effect = "Allow"
+    actions = [
+      "rds-db:connect"
+    ]
+    resources = [
+      "arn:aws:rds-db:${data.aws_region.current.region}:${local.aws_account_id}:dbuser:${var.db_cluster_resource_id}/${var.tm_iam_db_admin}"
+    ]
+  }
+}

--- a/aws-cloud/modules/secrets/hashicorp-vault/irsa_installer.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/irsa_installer.tf
@@ -1,9 +1,10 @@
 module "irsa_vault_installer" {
-  count = var.db_cluster_resource_id != null ? 1 : 0
+  count = var.iam_db_auth ? 1 : 0
   depends_on = [local.dependency]
   source     = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version    = "6.2.1"
   name       = "${var.project}-vault-installer"
+  path       = "/${var.tm_iam_prefix}/"
   policies = {
     "min_access" = aws_iam_policy.vault_installer_policy[0].arn
   }
@@ -18,15 +19,14 @@ module "irsa_vault_installer" {
 
 # permissions boundary for the Vault Installer. vault-installer-policy.json
 resource "aws_iam_policy" "vault_installer_policy" {
-  # TODO ?? for_each = var.db_cluster_resource_id != null ? { "enabled" = var.db_cluster_resource_id } : {}
-  count = var.db_cluster_resource_id != null ? 1 : 0
+  count = var.iam_db_auth ? 1 : 0
   name  = "${var.project}-vault-installer-policy"
   path  = "/${var.tm_iam_prefix}/"
   policy = data.aws_iam_policy_document.vault_installer_policy[0].json
 }
 
 data "aws_iam_policy_document" "vault_installer_policy" {
-  count = var.db_cluster_resource_id != null ? 1 : 0
+  count = var.iam_db_auth ? 1 : 0
   statement {
     sid    = "AllowRolesOnlyInPath"
     effect = "Allow"
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "vault_installer_policy" {
       "rds-db:connect"
     ]
     resources = [
-      "arn:aws:rds-db:${data.aws_region.current.region}:${local.aws_account_id}:dbuser:${var.db_cluster_resource_id}/${var.tm_iam_db_admin}"
+      "arn:aws:rds-db:${data.aws_region.current.region}:${local.aws_account_id}:dbuser:${var.db_cluster_resource_id}/${var.tm_db_admin}"
     ]
   }
 }

--- a/aws-cloud/modules/secrets/hashicorp-vault/irsa_installer.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/irsa_installer.tf
@@ -18,7 +18,7 @@ module "irsa_vault_installer" {
 
 # permissions boundary for the Vault Installer. vault-installer-policy.json
 resource "aws_iam_policy" "vault_installer_policy" {
-  # ?? for_each = var.db_cluster_resource_id != null ? { "enabled" = var.db_cluster_resource_id } : {}
+  # TODO ?? for_each = var.db_cluster_resource_id != null ? { "enabled" = var.db_cluster_resource_id } : {}
   count = var.db_cluster_resource_id != null ? 1 : 0
   name  = "${var.project}-vault-installer-policy"
   path  = "/${var.tm_iam_prefix}/"

--- a/aws-cloud/modules/secrets/hashicorp-vault/main.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/main.tf
@@ -15,8 +15,11 @@ locals {
   hault_tls_cert_name      = "hault-tls-cert"
   hault_root_tls_cert_name = "hault-root-ca-tls"
   root_token_secret_name   = "hault-init"
+  aws_account_id           = data.aws_caller_identity.main.account_id
   dependency               = jsonencode(var.dependency)
 }
+
+data "aws_caller_identity" "main" {}
 
 data "aws_region" "current" {}
 
@@ -287,6 +290,7 @@ resource "aws_kms_key" "hault" {
 
 resource "aws_iam_policy" "hault_kms" {
   name        = "${var.project}-VaultKMSUnsealPolicy"
+  path        = "/${var.tm_iam_prefix}/"
   description = "Allows Hault to use KMS for unsealing"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -302,6 +306,7 @@ module "hault_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "6.4.0"
   name                  = "${var.project}-hault-kms-unseal-role"
+  path                  = "/${var.tm_iam_prefix}/"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
   oidc_providers = {

--- a/aws-cloud/modules/secrets/hashicorp-vault/main.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/main.tf
@@ -307,8 +307,6 @@ module "hault_role" {
   version               = "6.4.0"
   name                  = "${var.project}-hault-kms-unseal-role"
   path                  = "/${var.tm_iam_prefix}/"
-  attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
   oidc_providers = {
     main = {
       provider_arn               = var.oidc_provider_arn

--- a/aws-cloud/modules/secrets/hashicorp-vault/outputs.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/outputs.tf
@@ -5,3 +5,7 @@ output "hault_address" {
 output "hault_root_ca_tls_name" {
   value = local.hault_root_tls_cert_name
 }
+
+output "vault_installer_role_arn" {
+  value = one(module.irsa_vault_installer[*].arn)
+}

--- a/aws-cloud/modules/secrets/hashicorp-vault/variables.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/variables.tf
@@ -16,6 +16,31 @@ variable "ingress_class_name" {
   default = "ingress-nginx-private"
 }
 
+variable "db_cluster_resource_id" {
+  description = "RDS DB Cluster DbClusterResourceId, optional to enable DB IAM mode."
+  type        = string
+  default     = null
+}
+
+variable "vault_installer_namespace" {
+  type    = string
+  default = "tm-system"
+}
+
+variable "vault_installer_serviceaccount" {
+  type    = string
+  default = "vault-installer"
+}
+
+variable "tm_iam_prefix" {
+  type = string
+}
+
+variable "tm_iam_db_admin" {
+  type    = string
+  default = "tm_admin_iam"
+}
+
 variable "dependency" {
   description = "Implicit module dependencies."
   type        = any

--- a/aws-cloud/modules/secrets/hashicorp-vault/variables.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/variables.tf
@@ -22,6 +22,11 @@ variable "db_cluster_resource_id" {
   default     = null
 }
 
+variable "iam_db_auth" {
+  type    = bool
+  default = false
+}
+
 variable "vault_installer_namespace" {
   type    = string
   default = "tm-system"
@@ -36,7 +41,8 @@ variable "tm_iam_prefix" {
   type = string
 }
 
-variable "tm_iam_db_admin" {
+variable "tm_db_admin" {
+  description = "DB admin username, used to set vault-installer role IAM policy during DB IAM auth."
   type    = string
   default = "tm_admin_iam"
 }


### PR DESCRIPTION
Support AWS IAM RBAC auth to RDS/Aurora db, for hault-strimzi environment.
* iam_db_auth mode flag
* vault-installer IAM policy allow tm_db_admin user
* set IAM role paths as tm_iam_prefix
* enable EKS IMDSv2 workaround required by Vault Core core-db-online-migrator