### PR TITLE
Support VC 5.9; TF version 1.15.

### DIFF
--- a/aws-cloud/environments/nonprod-asm-msk/main.tf
+++ b/aws-cloud/environments/nonprod-asm-msk/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.14.0"
+  required_version = "~> 1.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws-cloud/environments/nonprod-hault-strimzi/main.tf
+++ b/aws-cloud/environments/nonprod-hault-strimzi/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.14.0"
+  required_version = "~> 1.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws-cloud/modules/k8s/eks-managed-nodes/main.tf
+++ b/aws-cloud/modules/k8s/eks-managed-nodes/main.tf
@@ -105,6 +105,7 @@ module "eks" {
         # Unblock IMDSv2 from pod, workaround for core-db-online-migrator calls ec2imds: GetRegion"
         http_put_response_hop_limit = 2
       }
+      iam_role_use_name_prefix = false
     }
   }
 }

--- a/aws-cloud/modules/secrets/aws-secrets-manager/main.tf
+++ b/aws-cloud/modules/secrets/aws-secrets-manager/main.tf
@@ -82,6 +82,7 @@ data "aws_iam_policy_document" "vault_installer_policy" {
       "iam:DeleteRole",
       "iam:PutRolePolicy",
       "iam:DeleteRolePolicy",
+      "iam:TagRole", # required by Vault Core 5.9
     ]
     resources = [
       "arn:aws:iam::${local.aws_account_id}:role/${var.tm_iam_prefix}/*"

--- a/aws-cloud/modules/secrets/hashicorp-vault/main.tf
+++ b/aws-cloud/modules/secrets/hashicorp-vault/main.tf
@@ -305,7 +305,7 @@ resource "aws_iam_policy" "hault_kms" {
 module "hault_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "6.4.0"
-  name                  = "${var.project}-hault-kms-unseal-role"
+  name                  = "${var.project}-hault-kms"
   path                  = "/${var.tm_iam_prefix}/"
   oidc_providers = {
     main = {


### PR DESCRIPTION
vault installer IAM policy for VC 5.9; Compatible with TF version 1.15; Allow longer project names.